### PR TITLE
Modifications for SDUpdater compatibility

### DIFF
--- a/src/SDUpdater.cpp
+++ b/src/SDUpdater.cpp
@@ -1,0 +1,132 @@
+// --- for SD-Updater -------
+// SDU.cpp 
+//    NoRi 2024-06-04
+// -------------------------
+#if defined( ENABLE_SD_UPDATER )
+
+#include <Arduino.h>
+#include <M5Unified.h>
+#include <ESP32-targz.h>
+#include <M5StackUpdater.h>
+#include "SDUpdater.h"
+
+
+//#define TFCARD_CS_PIN 4
+#define SDU_SKIP_TMR 5000 // skip timer : ms
+//#define SERVO_TXT "/servo.txt"
+
+//bool USE_SERVO_ST;
+//int SERVO_PIN_X;
+//int SERVO_PIN_Y;
+
+//bool SdBegin();
+
+
+void SDU_lobby(String PROG_NAME)
+{
+  SDUCfg.setAppName(PROG_NAME.c_str()); // lobby screen label: application name
+  SDUCfg.setLabelMenu("< Menu");        // BtnA label: load menu.bin
+
+  checkSDUpdater(
+      SD,           // filesystem (default=SD)
+      MENU_BIN,     // path to binary (default=/menu.bin, empty string=rollback only)
+      SDU_SKIP_TMR, // wait delay, (default=0, will be forced to 2000 upon ESP.restart() )
+      TFCARD_CS_PIN // usually default=4 but your mileage may vary
+  );
+
+  Serial.println("SDU_lobby done");
+}
+
+
+#if 0
+bool SdBegin()
+{
+  // --- SD begin -------
+  int i = 0;
+  bool success = false;
+  Serial.println("SD.begin Start ...");
+
+  while (i < 3)
+  { // SDカードマウント待ち
+    success = SD.begin(GPIO_NUM_4, SPI, 15000000);
+    if (success)
+      return true;
+
+    Serial.println("SD Wait...");
+    delay(500);
+    i++;
+  }
+
+  if (i >= 3)
+  {
+    Serial.println("SD.begin faile ...");
+    return false;
+  }
+  else
+    return true;
+}
+
+
+bool servoTxtSDRead()
+{
+  if (!SdBegin())
+  {
+    SD.end();
+    return false;
+  }
+
+  File fs = SD.open(SERVO_TXT, FILE_READ);
+  if (!fs)
+  {
+    SD.end();
+    return false;
+  }
+
+  size_t sz = fs.size();
+  char buf[sz + 1];
+  fs.read((uint8_t *)buf, sz);
+  buf[sz] = 0;
+  fs.close();
+
+  int y = 0;
+  int z = 0;
+  for (int x = 0; x < sz; x++)
+  {
+    if (buf[x] == 0x0a || buf[x] == 0x0d)
+      buf[x] = 0;
+    else if (!y && x > 0 && !buf[x - 1] && buf[x])
+      y = x;
+    else if (!z && x > 0 && !buf[x - 1] && buf[x])
+      z = x;
+  }
+
+  String SV_ON_OFF = "";
+  String SV_PORT_X = "";
+  String SV_PORT_Y = "";
+
+  SV_ON_OFF = String(buf);
+  SV_PORT_X = String(&buf[y]);
+  SV_PORT_Y = String(&buf[z]);
+
+  if (SV_ON_OFF == "on" || SV_ON_OFF == "ON")
+    USE_SERVO_ST = true;
+  else
+    USE_SERVO_ST = false;
+
+  int sx = SV_PORT_X.toInt();
+  int sy = SV_PORT_Y.toInt();
+  if (sx != 0 && sy != 0)
+  {
+    SERVO_PIN_X = sx;
+    SERVO_PIN_Y = sy;
+  }
+
+  Serial.println("USE_SERVO   = " + SV_ON_OFF);
+  Serial.println("SERVO PIN_X = " + String(SERVO_PIN_X, 10));
+  Serial.println("SERVO PIN_Y = " + String(SERVO_PIN_Y, 10));
+
+  return true;
+}
+#endif
+
+#endif

--- a/src/SDUpdater.h
+++ b/src/SDUpdater.h
@@ -1,0 +1,15 @@
+#ifndef _SD_UPDATER_H
+#define _SD_UPDATER_H
+
+#if defined( ENABLE_SD_UPDATER )
+
+extern bool USE_SERVO_ST;
+extern int SERVO_PIN_X;
+extern int SERVO_PIN_Y;
+
+extern void SDU_lobby(String PROG_NAME);
+extern bool servoTxtSDRead();
+
+#endif  // ENABLE_SD_UPDATER
+
+#endif  // _SD_UPDATER_H

--- a/src/Stackchan_system_config.h
+++ b/src/Stackchan_system_config.h
@@ -67,10 +67,6 @@ class StackchanSystemConfig {
         bool _takao_base;                                    // Takao_Baseを使い後ろから給電する場合にtrue
         String _servo_type_str;
         uint8_t _servo_type;                                 // サーボの種類 (0: PWMサーボ, 1: Feetech SCS0009)
-        String _extend_config_filename;                      // 使用するアプリ側で拡張した設定が必要な場合に使用
-        uint32_t _extend_config_filesize;                    // 拡張設定ファイルのサイズ
-        String _secret_config_filename;                      // 個人情報の設定値を定義したファイル
-        uint32_t _secret_config_filesize;                    // 個人情報設定ファイルのサイズ
         secret_config_s _secret_config;                      // 個人情報の構造体
         bool _secret_config_show;                            // 個人情報をログに出すかどうか
         void setDefaultParameters();
@@ -82,7 +78,9 @@ class StackchanSystemConfig {
     public:
         StackchanSystemConfig();
         ~StackchanSystemConfig();
-        void loadConfig(fs::FS& fs, const char *app_yaml_filename, uint32_t app_yaml_filesize=2048, const char* basic_yaml_filename = "/yaml/SC_BasicConfig.yaml", uint32_t basic_yaml_filesize=2048);
+        void loadConfig(fs::FS& fs, const char *app_yaml_filename, uint32_t app_yaml_filesize=2048,
+                        const char* secret_yaml_filename = "/yaml/SC_SecConfig.yaml", uint32_t secret_yaml_filesize=2048,
+                        const char* basic_yaml_filename = "/yaml/SC_BasicConfig.yaml", uint32_t basic_yaml_filesize=2048);
 
         void printAllParameters();
 
@@ -103,6 +101,9 @@ class StackchanSystemConfig {
         virtual void loadExtendConfig(fs::FS& fs, const char* yaml_filename, uint32_t yaml_size);
         virtual void setExtendSettings(DynamicJsonDocument doc);
         virtual void printExtParameters(void);
+
+        virtual void basicConfigNotFoundCallback(void);
+        virtual void secretConfigNotFoundCallback(void);
 
 };
 


### PR DESCRIPTION
こちら https://github.com/ronron-gh/AI_StackChan2_FuncCall/issues/2#issue-2341501857 で進めている、
SDUpdaterへの対応に伴い以下の修正をしました。ご指摘やご要望などありましたら修正しますので、
ご確認のほど宜しくお願いいたしますm(__)m

- SDUpdater.cppとSDUpdater.hを追加
- YAMLファイルオープン失敗時のコールバック関数を仮想関数として追加
- SC_SecConfig.yamlのデフォルト名もloadConfig()の引数に追加
- SC_BasicConfig.yamlから SC_SecConfig.yaml及びSC_ExConfig.yamlのファイル名、サイズを削除（loadConfig()の引数で指定するため）